### PR TITLE
Error handling for `@app.call`

### DIFF
--- a/lib/rack/ltsv_logger.rb
+++ b/lib/rack/ltsv_logger.rb
@@ -28,7 +28,7 @@ module Rack
         uri: env["PATH_INFO"],
         query: env["QUERY_STRING"].empty? ? "" : "?"+env["QUERY_STRING"],
         protocol: env["HTTP_VERSION"],
-        status: status.to_s[0..3],
+        status: extract_status(status),
         size: extract_content_length(headers),
         reqtime: "%0.6f" % reqtime,
       }
@@ -49,6 +49,10 @@ module Rack
     def extract_content_length(headers)
       value = headers && headers['Content-Length'] or return '-'
       value.to_s == '0' ? '-' : value
+    end
+
+    def extract_status(status)
+      status.nil? ? "500" : status.to_s[0..3]
     end
   end
 end

--- a/lib/rack/ltsv_logger.rb
+++ b/lib/rack/ltsv_logger.rb
@@ -14,7 +14,7 @@ module Rack
       began_at = Time.now.instance_eval { to_i + (usec/1000000.0) }
 
       status, headers, body = @app.call(env)
-
+    ensure
       now = Time.now
       reqtime = now.instance_eval { to_i + (usec/1000000.0) } - began_at
 
@@ -47,7 +47,7 @@ module Rack
     end
 
     def extract_content_length(headers)
-      value = headers['Content-Length'] or return '-'
+      value = headers && headers['Content-Length'] or return '-'
       value.to_s == '0' ? '-' : value
     end
   end

--- a/spec/ltsv_logger_spec.rb
+++ b/spec/ltsv_logger_spec.rb
@@ -95,6 +95,7 @@ describe Rack::LtsvLogger do
       params = parse_ltsv(@output.string)
       expect(params).not_to be_empty
       expect(params['x_runtime']).to eq('1.234')
+      expect(params['status']).to eq('500')
     end
   end
 end

--- a/spec/ltsv_logger_spec.rb
+++ b/spec/ltsv_logger_spec.rb
@@ -8,6 +8,12 @@ describe Rack::LtsvLogger do
     }
   end
 
+  def error_app
+    lambda { |env|
+      raise ArgumentError, "error test"
+    }
+  end
+
   def parse_ltsv(ltsv)
     Hash[*(ltsv.chomp.split("\t").map {|e| e.split(":", 2) }.flatten)]
   end
@@ -67,6 +73,27 @@ describe Rack::LtsvLogger do
     it 'GET /get' do
       Rack::MockRequest.new(subject).get('/get', env)
       params = parse_ltsv(@output.string)
+      expect(params['x_runtime']).to eq('1.234')
+    end
+  end
+
+  context 'when app error occured' do
+    let(:appends) do
+      { x_runtime: Proc.new {|env| '1.234' } }
+    end
+
+    subject do
+      @output = StringIO.new
+      Rack::Lint.new( Rack::LtsvLogger.new(error_app, @output, appends) )
+    end
+
+    it 'GET /get' do
+      expect {
+        Rack::MockRequest.new(subject).get('/get', env)
+      }.to raise_error ArgumentError
+
+      params = parse_ltsv(@output.string)
+      expect(params).not_to be_empty
       expect(params['x_runtime']).to eq('1.234')
     end
   end


### PR DESCRIPTION
Thank you for your development. `rack-ltsv_logger` is nice logging tool.
When error occurred in calling `@app.call`, then nothing logged. I want Application Logger working (logging) in anytime.

- ensure error in `@app.call`. (then, `[status, headers, body]` will be `[nil, nil, nil]`)
- status will be 500 for logging, not overwrite.
- headers allows nil, not overwrite.